### PR TITLE
Add otp messages

### DIFF
--- a/src/pyubx2/ubxtypes_core.py
+++ b/src/pyubx2/ubxtypes_core.py
@@ -182,6 +182,7 @@ UBX_MSGIDS = {
     b"\x06\x17": "CFG-NMEA",  # NB: 3 versions of this
     b"\x06\x22": "CFG-NVS",
     b"\x06\x1e": "CFG-ODO",
+    b"\x06\x41": "CFG-OTP",
     b"\x06\x32": "CFG-PM",  # obsolete M5/6
     b"\x06\x3b": "CFG-PM2",
     b"\x06\x86": "CFG-PMS",

--- a/src/pyubx2/ubxtypes_get.py
+++ b/src/pyubx2/ubxtypes_get.py
@@ -782,6 +782,9 @@ UBX_PAYLOADS_GET = {
         "cogLpGain": U1,
         "reserved3": U2,
     },
+    "CFG-OTP": {
+        "otpContent": A256
+    },
     "CFG-PM": {
         "version": U1,
         "reserved1": U1,

--- a/src/pyubx2/ubxtypes_poll.py
+++ b/src/pyubx2/ubxtypes_poll.py
@@ -74,6 +74,7 @@ UBX_PAYLOADS_POLL = {
     "CFG-NMEA": {},
     "CFG-NVS": {},
     "CFG-ODO": {},
+    "CFG-OTP": {},
     "CFG-PM2": {},
     "CFG-PM": {},
     "CFG-PMS": {},


### PR DESCRIPTION
Add CFG-OTP message descriptor, note that the set cannot be encoded using this library as it uses a non-standard representation.